### PR TITLE
(update) added event argument hitchhiking

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
 , "author": {
     "name": "Michael Wheeler"
   }
-, "version": "0.0.3"
+, "contributors": [
+    {
+      "name": "Dave Timmerman"
+    }
+  ]
+, "version": "0.0.4"
 , "licenses": [
     {
       "type": "MIT"

--- a/spec/stateMachineSpecs.js
+++ b/spec/stateMachineSpecs.js
@@ -113,6 +113,19 @@
     ok(_out);
   });
 
+  test('enter methods is called with event arguments', function () {
+    var _in;
+    newStates.build()
+      .state('simple', {
+        enter: function (data) { _in = data }
+      })
+    .event('fall', 'young', 'simple')
+    ;
+
+    newStates.fall({some: 'data'});
+    q.equal(_in, [{some: 'data'}]);
+  });
+
   test('does not overwrite existing properties', function () {
     var st = states(function () {
       this.state('simple');

--- a/spec/stateMachineSpecs.js
+++ b/spec/stateMachineSpecs.js
@@ -114,16 +114,20 @@
   });
 
   test('enter method is called with event method parameters', function () {
-    var _in;
+    var _in1, _in2;
     newStates.build()
       .state('simple', {
-        enter: function (data) { _in = data }
+        enter: function (str, data) {
+          _in1 = str;
+          _in2 = data;
+        }
       })
-    .event('fall', 'young', 'simple')
+    .event('withParams', 'young', 'simple')
     ;
 
-    newStates.fall({some: 'data'});
-    q.equal(_in, {'0': {some: 'data'}});
+    newStates.withParams('a string', {some: 'data'});
+    q.equal(_in1, 'a string');
+    q.equal(_in2, {some: 'data'});
   });
 
   test('does not overwrite existing properties', function () {

--- a/spec/stateMachineSpecs.js
+++ b/spec/stateMachineSpecs.js
@@ -130,6 +130,21 @@
     q.equal(_in2, {some: 'data'});
   });
 
+  test('eventName is added to enter method parameters', function () {
+    var _in;
+    newStates.build()
+      .state('simple', {
+        enter: function (str, data, name) {
+          _in = name;
+        }
+      })
+    .event('withParams', 'young', 'simple')
+    ;
+
+    newStates.withEventName('a string', {some: 'data'});
+    q.equal(_in, 'simple');
+  });
+
   test('does not overwrite existing properties', function () {
     var st = states(function () {
       this.state('simple');

--- a/spec/stateMachineSpecs.js
+++ b/spec/stateMachineSpecs.js
@@ -123,7 +123,7 @@
     ;
 
     newStates.fall({some: 'data'});
-    q.equal(_in, [{some: 'data'}]);
+    q.equal(_in, {'0': {some: 'data'}});
   });
 
   test('does not overwrite existing properties', function () {

--- a/spec/stateMachineSpecs.js
+++ b/spec/stateMachineSpecs.js
@@ -113,7 +113,7 @@
     ok(_out);
   });
 
-  test('enter methods is called with event arguments', function () {
+  test('enter method is called with event method parameters', function () {
     var _in;
     newStates.build()
       .state('simple', {

--- a/stateMachine.js
+++ b/stateMachine.js
@@ -121,9 +121,9 @@
           currentState = me._states[name];
 
           me.onChange(me.currentState(), prev.name, args);
-          args.push(me.currentState())
-          is(currentState.enter, 'Function') && currentState.enter.apply(undefined, args);
+          args.push(me.currentState());
           is(prev.leave, 'Function') && prev.leave();
+          is(currentState.enter, 'Function') && currentState.enter.apply(undefined, args);
         }
 
       , trigger: function (eventName, args) {

--- a/stateMachine.js
+++ b/stateMachine.js
@@ -61,7 +61,7 @@
 
       function buildEventShortcut(name) {
         states[name] = states[name] || function () {
-          states.trigger(name);
+          states.trigger(name, arguments);
         };
       }
 
@@ -114,18 +114,18 @@
           return curr && curr.name;
         }
 
-      , setState: function (name) {
+      , setState: function (name, args) {
           var prev = me.currentState(true);
           currentState = me._states[name];
 
           me.onChange(me.currentState(), prev.name);
-          is(currentState.enter, 'Function') && currentState.enter();
+          is(currentState.enter, 'Function') && currentState.enter(args);
           is(prev.leave, 'Function') && prev.leave();
         }
 
-      , trigger: function (eventName) {
+      , trigger: function (eventName, args) {
           var nextState = me.currentState(true).events[eventName];
-          nextState && me.setState(nextState);
+          nextState && me.setState(nextState, args);
         }
 
       , _states: {}

--- a/stateMachine.js
+++ b/stateMachine.js
@@ -120,7 +120,7 @@
           var prev = me.currentState(true);
           currentState = me._states[name];
 
-          me.onChange(me.currentState(), prev.name);
+          me.onChange(me.currentState(), prev.name, args);
           is(currentState.enter, 'Function') && currentState.enter.apply(undefined, args);
           is(prev.leave, 'Function') && prev.leave();
         }

--- a/stateMachine.js
+++ b/stateMachine.js
@@ -121,6 +121,7 @@
           currentState = me._states[name];
 
           me.onChange(me.currentState(), prev.name, args);
+          args.push(me.currentState())
           is(currentState.enter, 'Function') && currentState.enter.apply(undefined, args);
           is(prev.leave, 'Function') && prev.leave();
         }

--- a/stateMachine.js
+++ b/stateMachine.js
@@ -61,7 +61,9 @@
 
       function buildEventShortcut(name) {
         states[name] = states[name] || function () {
-          states.trigger(name, arguments);
+          var args = Array.prototype.slice.call(arguments);
+          var arr = args.sort();
+          states.trigger(name, arr);
         };
       }
 
@@ -119,7 +121,7 @@
           currentState = me._states[name];
 
           me.onChange(me.currentState(), prev.name);
-          is(currentState.enter, 'Function') && currentState.enter(args);
+          is(currentState.enter, 'Function') && currentState.enter.apply(undefined, args);
           is(prev.leave, 'Function') && prev.leave();
         }
 


### PR DESCRIPTION
For this **fine** state machine to be compatible with our envisioned payment workflow implementation, I need to be able to update our database **inside** the stateMachine itself. With this change we can add arguments to the event method and use them in the enter phase of the state change. See test for implementation
